### PR TITLE
Refactor visit history recording

### DIFF
--- a/packages/frontend/src/lib/store.ts
+++ b/packages/frontend/src/lib/store.ts
@@ -37,6 +37,30 @@ function calculateRequiredLegsToWin(settings: GameSettings): number {
   return Math.ceil(settings.legsToWin / 2);
 }
 
+function recordVisit(
+  state: GameStoreState,
+  player: Player,
+  darts: VisitDart[],
+): void {
+  if (darts.length === 0) return;
+  const currentLeg = state.historyLegs[state.currentLeg - 1];
+  if (!currentLeg) return;
+  const hasBust = darts.some((dart) => dart.isBust);
+  const totalScore = hasBust
+    ? 0
+    : darts.reduce((sum, dart) => sum + dart.validatedScore, 0);
+  currentLeg.visits.push({
+    playerId: player.id,
+    playerName: player.name,
+    legNumber: state.currentLeg,
+    darts: [...darts],
+    totalScore,
+    startedScore: player.score + totalScore,
+    endedScore: player.score,
+    timestamp: new Date().toISOString(),
+  });
+}
+
 type GamePhase = "setup" | "preGame" | "playing" | "gameOver";
 
 function isDoubleCheckoutScore(score: number): boolean {
@@ -210,25 +234,8 @@ export const createGameStore = (initState: GameStoreState = initialState) => {
           const activePlayer = state.players.find(
             (p) => p.id === state.activePlayerId,
           );
-          if (activePlayer && state.currentVisitDarts.length > 0) {
-            const currentLeg = state.historyLegs[state.currentLeg - 1];
-            const hasBust = state.currentVisitDarts.some((dart) => dart.isBust);
-            const totalScore = hasBust
-              ? 0
-              : state.currentVisitDarts.reduce(
-                  (sum, dart) => sum + dart.validatedScore,
-                  0,
-                );
-            currentLeg?.visits.push({
-              playerId: activePlayer.id,
-              playerName: activePlayer.name,
-              legNumber: state.currentLeg,
-              darts: [...state.currentVisitDarts],
-              totalScore,
-              startedScore: activePlayer.score + totalScore,
-              endedScore: activePlayer.score,
-              timestamp: new Date().toISOString(),
-            });
+          if (activePlayer) {
+            recordVisit(state, activePlayer, state.currentVisitDarts);
           }
 
           if (state.players.length > 1) {
@@ -320,23 +327,8 @@ export const createGameStore = (initState: GameStoreState = initialState) => {
 
           if (isLegWin) {
             const currentLeg = state.historyLegs[state.currentLeg - 1];
-            const totalScore = state.currentVisitDarts.reduce(
-              (sum, dart) => sum + dart.validatedScore,
-              0,
-            );
-            currentLeg?.visits.push({
-              playerId: p.id,
-              playerName: p.name,
-              legNumber: state.currentLeg,
-              darts: [...state.currentVisitDarts],
-              totalScore,
-              startedScore: p.score + totalScore,
-              endedScore: p.score,
-              timestamp: new Date().toISOString(),
-            });
-            if (currentLeg) {
-              currentLeg.winnerPlayerId = p.id;
-            }
+            recordVisit(state, p, state.currentVisitDarts);
+            if (currentLeg) currentLeg.winnerPlayerId = p.id;
 
             state.currentVisitScores = [];
             state.currentVisitDarts = [];


### PR DESCRIPTION
## Summary
- centralize visit history creation in a shared helper
- reuse the helper for end-of-visit and leg-win paths to avoid duplicate entries
- keep bust visit totals consistent with existing rules

fixes #146 