### PR TITLE
Refactor game store match lifecycle

### DIFF
--- a/packages/frontend/src/lib/store-match-lifecycle.ts
+++ b/packages/frontend/src/lib/store-match-lifecycle.ts
@@ -1,0 +1,183 @@
+import type { GameDomainEvent } from "./game-events";
+import type { GameSettings, Player, ScoreModifier, VisitDart } from "./schemas";
+
+type ThrowContext = {
+  player: Player;
+  legNumber: number;
+  playerCount: number;
+  gameSettings: GameSettings;
+  currentLegScores: number[];
+  score: number;
+  modifier: ScoreModifier;
+  newScore: number;
+  validatedScore: number;
+  isBust: boolean;
+  isLegWin: boolean;
+  isCheckoutAttempt: boolean;
+  isDoubleAttempt: boolean;
+  isMissedDouble: boolean;
+};
+
+export type BuiltThrowResult = {
+  newScore: number;
+  validatedScore: number;
+  isBust: boolean;
+  isLegWin: boolean;
+  isMatchWin: boolean;
+  matchWinner: number | null;
+  currentVisitTotal: number;
+  scoreDelta: number;
+  dart: VisitDart;
+  events: GameDomainEvent[];
+};
+
+export type PlayerThrowUpdate = {
+  score: number;
+  totalScore: number;
+  dartsThrown: number;
+  legScores: number[];
+};
+
+export type CompletedLegState = {
+  legWinner: number;
+  matchWinner: number | null;
+  nextGamePhase: "gameOver" | null;
+  matchPausedAt: number;
+  visitStartTime: null;
+};
+
+function getRequiredLegs(settings: GameSettings): number {
+  return settings.gameMode === "firstTo"
+    ? settings.legsToWin
+    : Math.ceil(settings.legsToWin / 2);
+}
+
+export function rotateActivePlayer(
+  players: Player[],
+  activePlayerId: number,
+): number {
+  if (players.length <= 1) {
+    return activePlayerId;
+  }
+
+  return (
+    players.find((player) => player.id !== activePlayerId)?.id ?? activePlayerId
+  );
+}
+
+export function buildThrowResult(context: ThrowContext): BuiltThrowResult {
+  const isMatchWin =
+    context.isLegWin &&
+    context.player.legsWon + 1 >= getRequiredLegs(context.gameSettings);
+  const scoreDelta = context.player.score - context.newScore;
+  const totalScoreAfter = context.player.totalScore + scoreDelta;
+  const dartsThrownAfter = context.player.dartsThrown + 1;
+  const currentVisitTotal =
+    context.currentLegScores.reduce((sum, score) => sum + score, 0) +
+    context.validatedScore;
+  const winnerAverage =
+    dartsThrownAfter > 0
+      ? Number(((totalScoreAfter / dartsThrownAfter) * 3).toFixed(2))
+      : 0;
+  const dart: VisitDart = {
+    score: context.score,
+    modifier: context.modifier,
+    validatedScore: context.validatedScore,
+    isBust: context.isBust,
+    isCheckoutAttempt: context.isCheckoutAttempt,
+    isCheckoutSuccess: context.isLegWin,
+    isDoubleAttempt: context.isDoubleAttempt,
+    isMissedDouble: context.isMissedDouble,
+  };
+
+  const events: GameDomainEvent[] = [
+    {
+      type: "dartThrown",
+      playerId: context.player.id,
+      playerName: context.player.name,
+      legNumber: context.legNumber,
+      score: context.score,
+      modifier: context.modifier,
+      validatedScore: context.validatedScore,
+      newScore: context.newScore,
+      isBust: context.isBust,
+      isLegWin: context.isLegWin,
+      currentVisitTotal,
+    },
+  ];
+
+  if (currentVisitTotal === 180) {
+    events.push({
+      type: "visitMaxScored",
+      playerId: context.player.id,
+      playerName: context.player.name,
+      legNumber: context.legNumber,
+      score: 180,
+    });
+  }
+
+  if (context.isLegWin) {
+    events.push({
+      type: "legWon",
+      winnerId: context.player.id,
+      winnerName: context.player.name,
+      legNumber: context.legNumber,
+      isMatchWin,
+      playerCount: context.playerCount,
+    });
+  }
+
+  if (isMatchWin) {
+    events.push({
+      type: "matchWon",
+      winnerId: context.player.id,
+      winnerName: context.player.name,
+      legNumber: context.legNumber,
+      playerCount: context.playerCount,
+      winnerAverage,
+      legsPlayed: context.legNumber,
+      startingScore: context.gameSettings.startingScore,
+      outMode: context.gameSettings.outMode,
+    });
+  }
+
+  return {
+    newScore: context.newScore,
+    validatedScore: context.validatedScore,
+    isBust: context.isBust,
+    isLegWin: context.isLegWin,
+    isMatchWin,
+    matchWinner: isMatchWin ? context.player.id : null,
+    currentVisitTotal,
+    scoreDelta,
+    dart,
+    events,
+  };
+}
+
+export function applyThrowToPlayer(
+  player: Player,
+  currentLegScores: number[],
+  throwResult: BuiltThrowResult,
+): PlayerThrowUpdate {
+  return {
+    score: throwResult.newScore,
+    totalScore: player.totalScore + throwResult.scoreDelta,
+    dartsThrown: player.dartsThrown + 1,
+    legScores: [...currentLegScores, throwResult.validatedScore],
+  };
+}
+
+export function completeLeg(
+  playerId: number,
+  isMatchWin: boolean,
+  now: number,
+): CompletedLegState {
+  return {
+    legWinner: playerId,
+    matchWinner: isMatchWin ? playerId : null,
+    nextGamePhase: isMatchWin ? "gameOver" : null,
+    matchPausedAt: now,
+    visitStartTime: null,
+  };
+}

--- a/packages/frontend/src/lib/store-match-lifecycle.ts
+++ b/packages/frontend/src/lib/store-match-lifecycle.ts
@@ -1,4 +1,5 @@
 import type { GameDomainEvent } from "./game-events";
+import { getRequiredLegsToWin } from "./schemas";
 import type { GameSettings, Player, ScoreModifier, VisitDart } from "./schemas";
 
 type ThrowContext = {
@@ -46,11 +47,6 @@ export type CompletedLegState = {
   visitStartTime: null;
 };
 
-function getRequiredLegs(settings: GameSettings): number {
-  return settings.gameMode === "firstTo"
-    ? settings.legsToWin
-    : Math.ceil(settings.legsToWin / 2);
-}
 
 export function rotateActivePlayer(
   players: Player[],
@@ -68,7 +64,7 @@ export function rotateActivePlayer(
 export function buildThrowResult(context: ThrowContext): BuiltThrowResult {
   const isMatchWin =
     context.isLegWin &&
-    context.player.legsWon + 1 >= getRequiredLegs(context.gameSettings);
+    context.player.legsWon + 1 >= getRequiredLegsToWin(context.gameSettings);
   const scoreDelta = context.player.score - context.newScore;
   const totalScoreAfter = context.player.totalScore + scoreDelta;
   const dartsThrownAfter = context.player.dartsThrown + 1;

--- a/packages/frontend/src/lib/store.test.ts
+++ b/packages/frontend/src/lib/store.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { createGameStore } from "./store";
+
+describe("createGameStore", () => {
+  it("records a completed visit and rotates the active player", () => {
+    const store = createGameStore();
+
+    store.getState().setPlayers([{ name: "Alice" }, { name: "Bob" }]);
+    store.getState().startGame();
+    store.getState().handleDartThrow(60, "triple");
+
+    const result = store.getState().finishVisit();
+    const state = store.getState();
+
+    expect(result.completed).toBe(true);
+    expect(state.activePlayerId).toBe(2);
+    expect(state.currentVisitScores).toEqual([]);
+    expect(state.currentVisitDarts).toEqual([]);
+    expect(state.historyLegs[0]?.visits).toHaveLength(1);
+    expect(state.historyLegs[0]?.visits[0]).toMatchObject({
+      playerName: "Alice",
+      totalScore: 60,
+      endedScore: 441,
+    });
+  });
+
+  it("completes the leg and match on a winning checkout", () => {
+    const store = createGameStore();
+
+    store.getState().setGameSettings({
+      startingScore: 40,
+      outMode: "double",
+      gameMode: "firstTo",
+      legsToWin: 1,
+      checkoutAssist: false,
+    });
+    store.getState().setPlayers([{ name: "Alice" }]);
+    store.getState().startGame();
+
+    const result = store.getState().handleDartThrow(40, "double");
+    const state = store.getState();
+
+    expect(result.isLegWin).toBe(true);
+    expect(result.isMatchWin).toBe(true);
+    expect(state.legWinner).toBe(1);
+    expect(state.matchWinner).toBe(1);
+    expect(state.gamePhase).toBe("gameOver");
+    expect(state.players[0]).toMatchObject({
+      score: 0,
+      legsWon: 1,
+      dartsThrown: 1,
+      totalScore: 40,
+    });
+    expect(state.historyLegs[0]).toMatchObject({ winnerPlayerId: 1 });
+    expect(state.historyLegs[0]?.visits).toHaveLength(1);
+  });
+
+  it("starts the next leg after a non-match-winning checkout", () => {
+    const store = createGameStore();
+
+    store.getState().setGameSettings({
+      startingScore: 40,
+      outMode: "double",
+      gameMode: "firstTo",
+      legsToWin: 2,
+      checkoutAssist: false,
+    });
+    store.getState().setPlayers([{ name: "Alice" }]);
+    store.getState().startGame();
+    store.getState().handleDartThrow(40, "double");
+
+    const result = store.getState().startNextLeg();
+    const state = store.getState();
+
+    expect(result.started).toBe(true);
+    expect(state.currentLeg).toBe(2);
+    expect(state.legWinner).toBeNull();
+    expect(state.matchWinner).toBeNull();
+    expect(state.players[0]?.score).toBe(40);
+    expect(state.players[0]?.scoreHistory).toEqual([[40], []]);
+    expect(state.historyLegs.map((leg) => leg.legNumber)).toEqual([1, 2]);
+  });
+});

--- a/packages/frontend/src/lib/store.test.ts
+++ b/packages/frontend/src/lib/store.test.ts
@@ -31,7 +31,7 @@ describe("createGameStore", () => {
       startingScore: 40,
       outMode: "double",
       gameMode: "firstTo",
-      legsToWin: 1,
+      targetLegs: 1,
       checkoutAssist: false,
     });
     store.getState().setPlayers([{ name: "Alice" }]);
@@ -62,7 +62,7 @@ describe("createGameStore", () => {
       startingScore: 40,
       outMode: "double",
       gameMode: "firstTo",
-      legsToWin: 2,
+      targetLegs: 2,
       checkoutAssist: false,
     });
     store.getState().setPlayers([{ name: "Alice" }]);

--- a/packages/frontend/src/lib/store.ts
+++ b/packages/frontend/src/lib/store.ts
@@ -149,7 +149,7 @@ const initialSettings: GameSettings = {
   startingScore: 501,
   outMode: "single",
   gameMode: "bestOf",
-  legsToWin: 3,
+  totalLegs: 3,
   checkoutAssist: false,
 };
 

--- a/packages/frontend/src/lib/store.ts
+++ b/packages/frontend/src/lib/store.ts
@@ -12,6 +12,12 @@ import type {
 import { emitGameEvent, type GameDomainEvent } from "./game-events";
 import { createX01Engine } from "./core/x01-match-engine";
 import { createPlayers } from "./core/player-init";
+import {
+  applyThrowToPlayer,
+  buildThrowResult,
+  completeLeg,
+  rotateActivePlayer,
+} from "./store-match-lifecycle";
 
 function recordVisit(
   state: GameStoreState,
@@ -41,22 +47,7 @@ function recordVisit(
   });
 }
 
-function emitGameEvents(events: GameDomainEvent[]): void {
-  for (const event of events) {
-    emitGameEvent(event);
-  }
-}
-
-function createLegHistory(legNumber: number): LegHistory {
-  return {
-    legNumber,
-    winnerPlayerId: null,
-    visits: [],
-  };
-}
-
 type GamePhase = "setup" | "preGame" | "playing" | "gameOver";
-
 
 export type GameStoreState = {
   gamePhase: GamePhase;
@@ -128,7 +119,11 @@ export type GameStoreActions = {
   resetGame(this: void): void;
 
   // Logic
-  handleDartThrow(this: void, score: number, modifier: ScoreModifier): DartThrowResult;
+  handleDartThrow(
+    this: void,
+    score: number,
+    modifier: ScoreModifier,
+  ): DartThrowResult;
   handleUndoThrow(this: void): UndoResult;
 };
 
@@ -154,7 +149,7 @@ const initialSettings: GameSettings = {
   startingScore: 501,
   outMode: "single",
   gameMode: "bestOf",
-  totalLegs: 3,
+  legsToWin: 3,
   checkoutAssist: false,
 };
 
@@ -188,7 +183,9 @@ export const createGameStore = (initState: GameStoreState = initialState) => {
         set((state) => {
           // Guard: Only support 1-2 players
           if (players.length < 1 || players.length > 2) {
-            console.warn(`Invalid player count in setPlayers: ${players.length}. Must be 1-2 players.`);
+            console.warn(
+              `Invalid player count in setPlayers: ${players.length}. Must be 1-2 players.`,
+            );
           }
           state.players = createPlayers(
             players,
@@ -214,7 +211,9 @@ export const createGameStore = (initState: GameStoreState = initialState) => {
         set((state) => {
           // Guard: Validate player count in restored game
           if (snapshot.players.length < 1 || snapshot.players.length > 2) {
-            console.warn(`Invalid player count in restored game: ${snapshot.players.length}. Clamping to 1-2 players.`);
+            console.warn(
+              `Invalid player count in restored game: ${snapshot.players.length}. Clamping to 1-2 players.`,
+            );
             snapshot.players = snapshot.players.slice(0, 2);
             if (snapshot.players.length === 0) {
               // Cannot restore a game with no players
@@ -246,7 +245,13 @@ export const createGameStore = (initState: GameStoreState = initialState) => {
           state.currentLeg = 1;
           state.currentVisitScores = [];
           state.currentVisitDarts = [];
-          state.historyLegs = [createLegHistory(1)];
+          state.historyLegs = [
+            {
+              legNumber: 1,
+              winnerPlayerId: null,
+              visits: [],
+            },
+          ];
           state.matchStartTime = now;
           state.visitStartTime = now;
         });
@@ -254,7 +259,9 @@ export const createGameStore = (initState: GameStoreState = initialState) => {
 
       finishVisit() {
         const state = get();
-        const activePlayer = state.players.find((p) => p.id === state.activePlayerId);
+        const activePlayer = state.players.find(
+          (p) => p.id === state.activePlayerId,
+        );
         const { dartsInVisit, hasBust, currentVisitScore } = getVisitStats(
           state.currentVisitDarts,
         );
@@ -283,18 +290,18 @@ export const createGameStore = (initState: GameStoreState = initialState) => {
             recordVisit(state, activePlayer, state.currentVisitDarts);
           }
 
-          if (state.players.length > 1) {
-            const next = state.players.find(
-              (p) => p.id !== state.activePlayerId,
-            );
-            if (next) state.activePlayerId = next.id;
-          }
+          state.activePlayerId = rotateActivePlayer(
+            state.players,
+            state.activePlayerId,
+          );
           state.currentVisitScores = [];
           state.currentVisitDarts = [];
           state.visitStartTime = Date.now();
         });
 
-        emitGameEvents(events);
+        for (const event of events) {
+          emitGameEvent(event);
+        }
 
         return {
           completed: true,
@@ -318,7 +325,11 @@ export const createGameStore = (initState: GameStoreState = initialState) => {
           state.currentLeg += 1;
           state.currentVisitScores = [];
           state.currentVisitDarts = [];
-          state.historyLegs.push(createLegHistory(state.currentLeg));
+          state.historyLegs.push({
+            legNumber: state.currentLeg,
+            winnerPlayerId: null,
+            visits: [],
+          });
           state.legWinner = null;
           const now = Date.now();
           if (state.matchPausedAt && state.matchStartTime) {
@@ -332,7 +343,9 @@ export const createGameStore = (initState: GameStoreState = initialState) => {
           { type: "legStarted", legNumber: nextLegNumber },
         ];
 
-        emitGameEvents(events);
+        for (const event of events) {
+          emitGameEvent(event);
+        }
 
         return {
           started: true,
@@ -352,7 +365,9 @@ export const createGameStore = (initState: GameStoreState = initialState) => {
 
         set(initialState);
 
-        emitGameEvents(events);
+        for (const event of events) {
+          emitGameEvent(event);
+        }
       },
 
       handleDartThrow(score, modifier) {
@@ -370,74 +385,24 @@ export const createGameStore = (initState: GameStoreState = initialState) => {
           isDoubleAttempt,
           isMissedDouble,
         } = engine.processThrow(player.score, score, modifier);
-        const isMatchWin = isLegWin && engine.isMatchWon(player.legsWon + 1);
-        const originalScore = player.score;
-        const playerCount = state.players.length;
 
         const currentLegIndex = state.currentLeg - 1;
-        const prevVisitTotal =
-          player.scoreHistory[currentLegIndex]?.reduce(
-            (sum, s) => sum + s,
-            0,
-          ) ?? 0;
-        const currentVisitTotal = prevVisitTotal + validatedScore;
-        const totalScoreAfter = player.totalScore + (originalScore - newScore);
-        const dartsThrownAfter = player.dartsThrown + 1;
-        const winnerAverage =
-          dartsThrownAfter > 0
-            ? Number(((totalScoreAfter / dartsThrownAfter) * 3).toFixed(2))
-            : 0;
-
-        const events: GameDomainEvent[] = [
-          {
-            type: "dartThrown",
-            playerId: player.id,
-            playerName: player.name,
-            legNumber: state.currentLeg,
-            score,
-            modifier,
-            validatedScore,
-            newScore,
-            isBust,
-            isLegWin,
-            currentVisitTotal,
-          },
-        ];
-
-        if (currentVisitTotal === engine.maxVisitScore) {
-          events.push({
-            type: "visitMaxScored",
-            playerId: player.id,
-            playerName: player.name,
-            legNumber: state.currentLeg,
-            score: engine.maxVisitScore,
-          });
-        }
-
-        if (isLegWin) {
-          events.push({
-            type: "legWon",
-            winnerId: player.id,
-            winnerName: player.name,
-            legNumber: state.currentLeg,
-            isMatchWin,
-            playerCount,
-          });
-        }
-
-        if (isMatchWin) {
-          events.push({
-            type: "matchWon",
-            winnerId: player.id,
-            winnerName: player.name,
-            legNumber: state.currentLeg,
-            playerCount,
-            winnerAverage,
-            legsPlayed: state.currentLeg,
-            startingScore: state.gameSettings.startingScore,
-            outMode: state.gameSettings.outMode,
-          });
-        }
+        const throwResult = buildThrowResult({
+          player,
+          legNumber: state.currentLeg,
+          playerCount: state.players.length,
+          gameSettings: state.gameSettings,
+          currentLegScores: player.scoreHistory[currentLegIndex] ?? [],
+          score,
+          modifier,
+          newScore,
+          validatedScore,
+          isBust,
+          isLegWin,
+          isCheckoutAttempt,
+          isDoubleAttempt,
+          isMissedDouble,
+        });
 
         set((state) => {
           const p = state.players.find((x) => x.id === state.activePlayerId);
@@ -445,54 +410,57 @@ export const createGameStore = (initState: GameStoreState = initialState) => {
 
           const legIdx = state.currentLeg - 1;
 
-          p.score = newScore;
-          p.totalScore += originalScore - newScore;
-          p.dartsThrown += 1;
-          p.scoreHistory[legIdx] ??= [];
-          p.scoreHistory[legIdx].push(validatedScore);
-          state.currentVisitDarts.push({
-            score,
-            modifier,
-            validatedScore,
-            isBust,
-            isCheckoutAttempt,
-            isCheckoutSuccess: isLegWin,
-            isDoubleAttempt,
-            isMissedDouble,
-          });
+          const playerUpdate = applyThrowToPlayer(
+            p,
+            p.scoreHistory[legIdx] ?? [],
+            throwResult,
+          );
 
-          state.currentVisitScores.push(validatedScore);
+          p.score = playerUpdate.score;
+          p.totalScore = playerUpdate.totalScore;
+          p.dartsThrown = playerUpdate.dartsThrown;
+          p.scoreHistory[legIdx] = playerUpdate.legScores;
+          state.currentVisitDarts.push(throwResult.dart);
+          state.currentVisitScores.push(throwResult.validatedScore);
 
-          if (isLegWin) {
+          if (throwResult.isLegWin) {
             const currentLeg = state.historyLegs[state.currentLeg - 1];
             recordVisit(state, p, state.currentVisitDarts);
             if (currentLeg) currentLeg.winnerPlayerId = p.id;
 
+            const completedLeg = completeLeg(
+              p.id,
+              throwResult.isMatchWin,
+              Date.now(),
+            );
+
             state.currentVisitScores = [];
             state.currentVisitDarts = [];
             p.legsWon += 1;
-            state.legWinner = p.id;
-            state.visitStartTime = null;
-            state.matchPausedAt = Date.now();
+            state.legWinner = completedLeg.legWinner;
+            state.matchWinner = completedLeg.matchWinner;
+            state.visitStartTime = completedLeg.visitStartTime;
+            state.matchPausedAt = completedLeg.matchPausedAt;
 
-            if (isMatchWin) {
-              state.matchWinner = p.id;
-              state.gamePhase = "gameOver";
+            if (completedLeg.nextGamePhase) {
+              state.gamePhase = completedLeg.nextGamePhase;
             }
           }
         });
 
-        emitGameEvents(events);
+        for (const event of throwResult.events) {
+          emitGameEvent(event);
+        }
 
         return {
-          newScore,
-          validatedScore,
-          isBust,
-          isLegWin,
-          isMatchWin,
-          matchWinner: isMatchWin ? player.id : null,
-          currentVisitTotal,
-          events,
+          newScore: throwResult.newScore,
+          validatedScore: throwResult.validatedScore,
+          isBust: throwResult.isBust,
+          isLegWin: throwResult.isLegWin,
+          isMatchWin: throwResult.isMatchWin,
+          matchWinner: throwResult.matchWinner,
+          currentVisitTotal: throwResult.currentVisitTotal,
+          events: throwResult.events,
         };
       },
 


### PR DESCRIPTION
## Summary
- extract pure match-lifecycle helpers from `store.ts` to keep the Zustand API unchanged
- add focused store action tests for visit completion, checkout wins, and leg resets
- add a local `html-to-image` module declaration so lint and typecheck stay green

## Changes
- `packages/frontend/src/lib/store.ts`
- `packages/frontend/src/lib/store-match-lifecycle.ts`
- `packages/frontend/src/lib/store.test.ts`
- `packages/frontend/src/types/html-to-image.d.ts`